### PR TITLE
Security: Adds missing pipeline metadata for security

### DIFF
--- a/.azure-pipelines/release-cli.yaml
+++ b/.azure-pipelines/release-cli.yaml
@@ -732,11 +732,14 @@ extends:
             displayName: Upload binaries (GitHub)
             # Only upload release if we're building a tag.
             condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
+            templateContext:
+              type: releaseJob
+              isProduction: true
+              inputs:
+              - input: pipelineArtifact
+                targetPath: $(artifactsDownloadLocation)
             steps:
               - checkout: none
-              - task: DownloadPipelineArtifact@2
-                inputs:
-                  path: $(artifactsDownloadLocation)
               - task: GithubRelease@1
                 displayName: 'Upload Artifacts to GitHub Release'
                 inputs:

--- a/.azure-pipelines/release-cli.yaml
+++ b/.azure-pipelines/release-cli.yaml
@@ -737,6 +737,7 @@ extends:
               isProduction: true
               inputs:
               - input: pipelineArtifact
+                artifactName: build-output-$(rid)
                 targetPath: $(artifactsDownloadLocation)
             steps:
               - checkout: none


### PR DESCRIPTION
Fixes #95 
Adds missing pipeline metadata as per https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/releasepipelines/releaseworkflows/releasejob?tabs=deploymentjob